### PR TITLE
Quantity型の足し算と引き算で大きな単位への変換は「例外」にする #12

### DIFF
--- a/src/main/java/com/example/quantity/Quantity.java
+++ b/src/main/java/com/example/quantity/Quantity.java
@@ -16,12 +16,12 @@ public class Quantity {
     }
 
     public Quantity add(Quantity other) {
-        int result = Math.addExact(value, opedand(other));
+        int result = Math.addExact(value, toSameUnit(other));
         return new Quantity(result, unit);
     }
 
     public Quantity subtract(Quantity other) {
-        int result = Math.subtractExact(value, opedand(other));
+        int result = Math.subtractExact(value, toSameUnit(other));
         return new Quantity(result, unit);
     }
 
@@ -30,13 +30,13 @@ public class Quantity {
         return new Quantity(result, unit);
     }
 
-    private int opedand(Quantity quantity) {
+    private int toSameUnit(Quantity quantity) {
         if (unit.isEqualTo(quantity.unit))
             return quantity.value;
         else if (unit.isPiece())
             return Math.multiplyExact(quantity.value, quantity.unit.piece());
-        else
-            return Math.floorDiv(quantity.value, unit.piece());
+
+        throw new IllegalArgumentException();
     }
 
     @Override

--- a/src/main/java/com/example/quantity/unit/Unit.java
+++ b/src/main/java/com/example/quantity/unit/Unit.java
@@ -12,7 +12,7 @@ public interface Unit {
     }
 
     default boolean isEqualTo(Unit other) {
-        return this.getClass() == other.getClass();
+        return this.getClass() == other.getClass() && piece() == other.piece();
     }
 
 }

--- a/src/test/java/com/example/quantity/QuantityTest.java
+++ b/src/test/java/com/example/quantity/QuantityTest.java
@@ -46,11 +46,7 @@ class QuantityTest {
         Quantity one = new Quantity(3, new BoxUnit(piece));
         Quantity other = new Quantity(50, new PieceUnit());
 
-        Quantity expected = new Quantity(5, new BoxUnit(piece));
-        Quantity actual = one.add(other);
-
-        assertEquals(expected.value, actual.value, "3箱(*20ピース) + 50ピース = 5箱");
-        assertEquals(expected.unit.getClass(), actual.unit.getClass(), "単位 = 箱");
+        assertThrows(IllegalArgumentException.class, () -> one.add(other), "加算時のピース・箱変換 → 例外");
     }
 
     @Test
@@ -67,11 +63,30 @@ class QuantityTest {
     }
 
     @Test
-    void addOverflow() {
+    void addDifferentUnitBoxes() {
+        int pieceOne = 20;
+        Quantity one = new Quantity(1, new BoxUnit(pieceOne));
+        int pieceOther = 24;
+        Quantity other = new Quantity(3, new BoxUnit(pieceOther));
+
+        assertThrows(IllegalArgumentException.class, () -> one.add(other), "異なる単位の箱の加算で例外");
+    }
+
+    @Test
+    void addPieceOverflow() {
         Quantity max = new Quantity(Integer.MAX_VALUE, new PieceUnit());
         Quantity other = new Quantity(1, new PieceUnit());
 
-        assertThrows(ArithmeticException.class, () -> max.add(other), "加算オーバーフロー");
+        assertThrows(ArithmeticException.class, () -> max.add(other), "ピースの加算オーバーフロー");
+    }
+
+    @Test
+    void addBoxOverflow() {
+        int piece = 24;
+        Quantity max = new Quantity(Integer.MAX_VALUE, new BoxUnit(piece));
+        Quantity other = new Quantity(1, new BoxUnit(piece));
+
+        assertThrows(ArithmeticException.class, () -> max.add(other), "箱の加算オーバーフロー");
     }
 
     @Test
@@ -105,11 +120,7 @@ class QuantityTest {
         Quantity one = new Quantity(3, new BoxUnit(piece));
         Quantity other = new Quantity(22, new PieceUnit());
 
-        Quantity expected = new Quantity(2, new BoxUnit(piece));
-        Quantity actual = one.subtract(other);
-
-        assertEquals(expected.value, actual.value, "3箱(*20ピース) - 22ピース = 2箱");
-        assertEquals(expected.unit.getClass(), actual.unit.getClass(), "単位 = 箱");
+        assertThrows(IllegalArgumentException.class, () -> one.subtract(other), "減算時のピース・箱変換 → 例外");
     }
 
     @Test
@@ -124,13 +135,32 @@ class QuantityTest {
         assertEquals(expected.value, actual.value, "5箱 - 3箱 = 2箱");
         assertEquals(expected.unit.getClass(), actual.unit.getClass(), "単位 = 箱");
     }
+    
+    @Test
+    void subtractDifferentUnitBoxes() {
+        int pieceOne = 20;
+        Quantity one = new Quantity(1, new BoxUnit(pieceOne));
+        int pieceOther = 24;
+        Quantity other = new Quantity(3, new BoxUnit(pieceOther));
+
+        assertThrows(IllegalArgumentException.class, () -> one.subtract(other), "異なる単位の箱の減算で例外");
+    }
 
     @Test
-    void subtractOverflow() {
+    void subtractPieceOverflow() {
         Quantity max = new Quantity(Integer.MIN_VALUE, new PieceUnit());
         Quantity other = new Quantity(1, new PieceUnit());
 
-        assertThrows(ArithmeticException.class, () -> max.subtract(other), "減算オーバーフロー");
+        assertThrows(ArithmeticException.class, () -> max.subtract(other), "ピースの減算オーバーフロー");
+    }
+
+    @Test
+    void subtractBoxOverflow() {
+        int piece = 24;
+        Quantity max = new Quantity(Integer.MIN_VALUE, new BoxUnit(piece));
+        Quantity other = new Quantity(1, new BoxUnit(piece));
+
+        assertThrows(ArithmeticException.class, () -> max.subtract(other), "箱の減算オーバーフロー");
     }
 
     @Test


### PR DESCRIPTION
フィードバックを対応しました。

> Unit#isEqualTO() の実装で、 class() の比較に加えて piece() の比較もする

piece()が異なる箱の加算減算も例外として扱う仕様としました。
該当のテストメソッドも追加しています。


> Quantity#opedand() の名前を、例えば、alignUnit() とか、意図を具体的に表現する名前を工夫する

toSameUnit()としました。
3語ですが、"同じ"の方が"揃える"や"統一"を表す言葉よりも明確な意味になるかと思いましたので。


> PieceUnitからBoxUnitへの変換

こちらは現時点では未実装です。