### PR TITLE
#49 DueDateとDueDateTestを、type.date パッケージから、model.duedateパッケージに移動、テストで、Days#valueへの参照がエラーになるので、Days#isEqualTo() を使うように変更

### DIFF
--- a/src/main/java/com/example/domain/model/duedate/DueDate.java
+++ b/src/main/java/com/example/domain/model/duedate/DueDate.java
@@ -1,4 +1,6 @@
-package com.example.domain.type.date;
+package com.example.domain.model.duedate;
+
+import com.example.domain.type.date.Days;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/example/domain/model/duedate/package-info.java
+++ b/src/main/java/com/example/domain/model/duedate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 期日の関心事
+ */
+package com.example.domain.model.duedate;

--- a/src/main/java/com/example/domain/type/date/Days.java
+++ b/src/main/java/com/example/domain/type/date/Days.java
@@ -5,6 +5,8 @@ import java.time.temporal.ChronoUnit;
 
 public class Days {
 
+    public static final Days Zero = new Days(0);
+
     long value;
 
     public Days(long value) {

--- a/src/test/java/com/example/domain/model/duedate/DueDateTest.java
+++ b/src/test/java/com/example/domain/model/duedate/DueDateTest.java
@@ -1,5 +1,6 @@
-package com.example.domain.type.date;
+package com.example.domain.model.duedate;
 
+import com.example.domain.type.date.Days;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -106,7 +107,8 @@ class DueDateTest {
         LocalDate date20190901 = LocalDate.of(2019, 9, 1);
         DueDate due20190901 = DueDate.of(date20190901);
         Days actual = due20190901.remainingDays(date20180831);
-        assertEquals(366, actual.value, String.format("%s - %s", due20190901, date20180831));
+        Days expected = new Days(366);
+        assertTrue(expected.isEqualTo(actual), String.format("%s - %s", due20190901, date20180831));
     }
 
     @Test
@@ -116,7 +118,8 @@ class DueDateTest {
         LocalDate other20180831 = LocalDate.of(2018, 8, 31);
         DueDate due20180831 = DueDate.of(date20180831);
         Days actual = due20180831.remainingDays(other20180831);
-        assertEquals(0, actual.value);
+        Days expected = Days.Zero;
+        assertTrue(expected.isEqualTo(actual));
     }
 
     @Test
@@ -135,7 +138,8 @@ class DueDateTest {
         LocalDate date20180901 = LocalDate.of(2018, 9, 1);
         DueDate due20170831 = DueDate.of(date20170831);
         Days actual = due20170831.daysPast(date20180901);
-        assertEquals(366, actual.value, String.format("%s - %s", date20180901, due20170831));
+        Days expected = new Days(366);
+        assertTrue(expected.isEqualTo(actual), String.format("%s - %s", date20180901, due20170831));
     }
 
     @Test
@@ -145,7 +149,8 @@ class DueDateTest {
         LocalDate other20180831 = LocalDate.of(2018, 8, 31);
         DueDate due20180831 = DueDate.of(date20180831);
         Days actual = due20180831.daysPast(other20180831);
-        assertEquals(0, actual.value);
+        Days expected = Days.Zero;
+        assertTrue(expected.isEqualTo(actual));
     }
 
     @Test


### PR DESCRIPTION
#49