### PR TITLE
Amount 上限額の初期化を修正

### DIFF
--- a/src/main/java/com/example/domain/model/jjugccc2024/beginner/range/Amount.java
+++ b/src/main/java/com/example/domain/model/jjugccc2024/beginner/range/Amount.java
@@ -3,7 +3,7 @@ package com.example.domain.model.jjugccc2024.beginner.range;
 class Amount {
     int 金額;
 
-    static final Amount 上限額 = Amount.of(1_000_000);
+    static final Amount 上限額 = new Amount(1_000_000);
     static final Amount 一円 = Amount.of(1);
 
     private Amount(int 金額) {


### PR DESCRIPTION
本リポジトリにより学習させていただいている者です。
気になった点があり、PRの形で問い合わせさせていただきますmm

---
`domain/model/jjugccc2024/beginner/range/Amount.java`で`上限額`は`Amount.of()`を使って定義されていますが、`上限額`は`Amount.of()`内で参照されるため、`Amount.of()`を使わない方法でインスタンス化する必要があると思います。
（実際、Amount等のテスト実行時、Amount.of()呼び出し時に`上限額`がnullであることによりNPEが発生すると思います）

自分の認識が誤っている、対応不要である、その他の対応が適切であるなどの場合は、ご放念くださいmm